### PR TITLE
switch port and KAT to define in secrets.json, switch wifi to insecur…

### DIFF
--- a/src/Wippersnapper.cpp
+++ b/src/Wippersnapper.cpp
@@ -1896,7 +1896,7 @@ void Wippersnapper::runNetFSM() {
       break;
     case FSM_NET_ESTABLISH_MQTT:
       WS_DEBUG_PRINTLN("Attempting to connect to Adafruit IO...");
-      WS._mqtt->setKeepAliveInterval(WS_KEEPALIVE_INTERVAL_MS / 1000);
+      WS._mqtt->setKeepAliveInterval(WS._mqttKeepAliveTime / 1000);
       // Attempt to connect
       maxAttempts = 5;
       while (maxAttempts > 0) {

--- a/src/Wippersnapper.h
+++ b/src/Wippersnapper.h
@@ -313,6 +313,8 @@ public:
 
   const char *_mqttBrokerURL = nullptr; /*!< MQTT Broker URL */
   uint16_t _mqtt_port = 8883;           /*!< MQTT Broker Port */
+  uint16_t _mqttKeepAliveTime =
+      WS_KEEPALIVE_INTERVAL_MS; /*! < MQTT KeepAlive Time */
 
   // AIO credentials
   const char *_username = NULL; /*!< Adafruit IO username */

--- a/src/network_interfaces/Wippersnapper_ESP32.h
+++ b/src/network_interfaces/Wippersnapper_ESP32.h
@@ -23,7 +23,8 @@
 #include "Adafruit_MQTT.h"
 #include "Adafruit_MQTT_Client.h"
 #include "Arduino.h"
-#include <WiFiClientSecure.h>
+// #include <WiFiClient.h>
+#include <WiFi.h>
 extern Wippersnapper WS;
 
 /****************************************************************************/
@@ -42,7 +43,7 @@ public:
   Wippersnapper_ESP32() : Wippersnapper() {
     _ssid = 0;
     _pass = 0;
-    _mqtt_client = new WiFiClientSecure;
+    _mqtt_client = new WiFiClient;
   }
 
   /**************************************************************************/
@@ -147,9 +148,9 @@ public:
   void setupMQTTClient(const char *clientID) {
     if (WS._mqttBrokerURL == nullptr) {
       WS._mqttBrokerURL = "io.adafruit.com";
-      _mqtt_client->setCACert(_aio_root_ca_prod);
+      //_mqtt_client->setCACert(_aio_root_ca_prod);
     } else {
-      _mqtt_client->setCACert(_aio_root_ca_staging);
+      //_mqtt_client->setCACert(_aio_root_ca_staging);
     }
 
     WS._mqtt =
@@ -185,10 +186,10 @@ public:
   const char *connectionType() { return "ESP32"; }
 
 protected:
-  const char *_ssid;              ///< WiFi SSID
-  const char *_pass;              ///< WiFi password
-  const char *_mqttBrokerURL;     ///< MQTT broker URL
-  WiFiClientSecure *_mqtt_client; ///< Pointer to a secure MQTT client object
+  const char *_ssid;          ///< WiFi SSID
+  const char *_pass;          ///< WiFi password
+  const char *_mqttBrokerURL; ///< MQTT broker URL
+  WiFiClient *_mqtt_client;   ///< Pointer to a secure MQTT client object
 
   const char *_aio_root_ca_staging =
       "-----BEGIN CERTIFICATE-----\n"

--- a/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
+++ b/src/provisioning/littlefs/WipperSnapper_LittleFS.cpp
@@ -120,6 +120,10 @@ void WipperSnapper_LittleFS::parseSecrets() {
 
   // Optionally set the Adafruit.io URL
   WS._mqttBrokerURL = _doc["io_url"];
+  // Optionally set the MQTT broker port
+  WS._mqtt_port = _doc["io_port"];
+  // Optionally set the MQTT keepalive time, in milliseconds
+  WS._mqttKeepAliveTime = _doc["keep_alive_millis"];
 
   // Get (optional) setting for the status pixel brightness
   float status_pixel_brightness = _doc["status_pixel_brightness"];

--- a/src/provisioning/tinyusb/Wippersnapper_FS.cpp
+++ b/src/provisioning/tinyusb/Wippersnapper_FS.cpp
@@ -426,6 +426,10 @@ void Wippersnapper_FS::parseSecrets() {
   // Optionally set the MQTT broker url (used to switch btween prod. and
   // staging)
   WS._mqttBrokerURL = doc["io_url"];
+  // Optionally set the MQTT broker port
+  WS._mqtt_port = doc["io_port"];
+  // Optionally set the MQTT keepalive time, in milliseconds
+  WS._mqttKeepAliveTime = doc["keep_alive_millis"];
 
   // Get (optional) setting for the status pixel brightness
   float status_pixel_brightness = doc["status_pixel_brightness"];


### PR DESCRIPTION
New fields must be in `secrets.json` file for use with NGROK
`io_url` should be the ngrok.io address
`io_port` should be the ngrok.io forwarder port
`keep_alive_millis` is the MQTT Client (device) keepalive time, in **milliseconds**

```
    "io_url":"2.tcp.ngrok.io",
    "io_port":1234,
    "keep_alive_millis":900000,
```

`ngrok tcp 1884`  to get the values above ☝️ 